### PR TITLE
Fix 'list shopcart'

### DIFF
--- a/service/models.py
+++ b/service/models.py
@@ -152,6 +152,12 @@ class Shopcart(db.Model):
         return cls.query.all()
     
     @classmethod
+    def all_shopcart(cls):
+        """ Returns all of the Shopcarts in the database """
+        logger.info("Processing all Shopcarts")
+        return cls.query.filter(cls.item_id == -1).all()
+    
+    @classmethod
     def find_shopcart(cls, user_id):
         """ Finds a shopcart (including items it has) by user_id """
         logger.info("Processing lookup for user id %s...", user_id)

--- a/service/routes.py
+++ b/service/routes.py
@@ -66,7 +66,7 @@ def create_shopcarts():
 def list_shopcarts():
     """Returns all of the Shopcarts"""
     app.logger.info("Request for shopcart list")
-    shopcarts = Shopcart.all()
+    shopcarts = Shopcart.all_shopcart()
     results = [shopcart.serialize() for shopcart in shopcarts]
     app.logger.info("Returning %d shopcarts", len(results))
     return make_response(jsonify(results), status.HTTP_200_OK)

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -101,7 +101,8 @@ class TestYourResourceServer(TestCase):
 
     def test_get_shopcart_list(self):
         """Get a list of Shopcart"""
-        self._create_shopcarts(3)
+        self._create_shopcarts(2)
+        self._create_items(3) #one more shopcart with items
         resp = self.app.get(BASE_URL)
         self.assertEqual(resp.status_code, status.HTTP_200_OK)
         data = resp.get_json()


### PR DESCRIPTION
I found that actually .all() is used by .find_item(), etc. So, I added a new class method  .all_shopcart() to fix it.