### PR TITLE
improve responses and enable casting int to float for price

### DIFF
--- a/service/models.py
+++ b/service/models.py
@@ -108,7 +108,7 @@ class Shopcart(db.Model):
                         "Invalid type for int [quantity]: "
                         + str(type(data["quantity"]))
                 )
-            if isinstance(data["price"], float):
+            if isinstance(data["price"], float) or isinstance(data["price"], int):
                 self.price = data["price"]
             else:
                 raise DataValidationError(
@@ -118,11 +118,11 @@ class Shopcart(db.Model):
                 
         except KeyError as error:
             raise DataValidationError(
-                "Invalid Shopcart: missing " + error.args[0]
+                "Invalid Shopcart item: missing " + error.args[0]
             )
         except TypeError as error:
             raise DataValidationError(
-                "Invalid Shopcart: body of request contained bad or no data"
+                "Invalid Shopcart item: body of request contained bad or no data"
             )
         return self
 

--- a/service/routes.py
+++ b/service/routes.py
@@ -57,29 +57,31 @@ def create_shopcarts():
     check_content_type("application/json")
     req = request.get_json()
     if not "user_id" in req.keys() or not isinstance(req["user_id"], int):
-         return make_response(
-            jsonify(""), status.HTTP_400_BAD_REQUEST
+        abort(status.HTTP_400_BAD_REQUEST, f"Invalid user id.")
+    if Shopcart.find_shopcart(req["user_id"]):
+        user_id = req["user_id"]
+        abort(
+            status.HTTP_400_BAD_REQUEST, 
+            f"User with id '{user_id}' already has a non-empty shopcart.",
         )
     
     shopcarts = []
-
-    if ("item_id" in req.keys()):
-        shopcart = Shopcart()
-        shopcart.deserialize(req)
-        shopcart.create()
-    
-    elif ("items" in req.keys()):
+    shopcarts_deserialize = []
+    if "item_id" in req.keys():
+        shopcarts.append(req)
+    elif "items" in req.keys():
         shopcarts = req["items"]
-
     for s in shopcarts:
-        shopcart = Shopcart()
-        shopcart.deserialize(s)
-        shopcart.create()
+        if s["user_id"] == req["user_id"]:
+            shopcart = Shopcart()
+            shopcart.deserialize(s)
+            shopcart.create()
+            shopcarts_deserialize.append(shopcart)
     location_url = url_for("get_shopcarts", shopcart_id=req["user_id"], _external=True)
-    
     app.logger.info("Shopcart with ID [%s] created.", req["user_id"])
+    results = [shopcart.serialize() for shopcart in shopcarts_deserialize]
     return make_response(
-        jsonify(req["user_id"]), status.HTTP_201_CREATED, {"Location": location_url}
+        jsonify(results), status.HTTP_201_CREATED, {"Location": location_url}
     )
 
 ######################################################################

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -148,7 +148,7 @@ class TestYourResourceServer(TestCase):
         self.assertIsNotNone(location)
         # Check the data is correct
         new_shopcart = resp.get_json()
-        self.assertEqual(new_shopcart, 10023, "User IDs do not match")
+        self.assertEqual(new_shopcart, [], "Expect to return an empty list")
         #self.assertEqual(new_shopcart["item_id"], test_shopcart.item_id, "item IDs do not match")
         # Check that the location header was correct
         # test_item = ItemFactory(user_id = test_shopcart.user_id, item_id = test_shopcart.item_id+1)
@@ -174,7 +174,7 @@ class TestYourResourceServer(TestCase):
         self.assertIsNotNone(location)
         # Check the data is correct
         new_shopcart = resp.get_json()
-        self.assertEqual(new_shopcart, shopcart.user_id, "User IDs do not match")
+        self.assertEqual(new_shopcart[0]["user_id"], shopcart.user_id, "User IDs do not match")
 
     def test_create_shopcart_with_item_list(self):
         """Create a new Shopcart with a list of items"""
@@ -196,7 +196,7 @@ class TestYourResourceServer(TestCase):
         self.assertIsNotNone(location)
         # Check the data is correct
         new_shopcart = resp.get_json()
-        self.assertEqual(new_shopcart, shopcart.user_id, "User IDs do not match")
+        self.assertEqual(new_shopcart[0]["user_id"], shopcart.user_id, "User IDs do not match")
 
     def test_create_shopcart_no_data(self):
         """Create a Shopcart with missing data"""
@@ -220,6 +220,24 @@ class TestYourResourceServer(TestCase):
         test_shopcart = ItemFactory()
         logging.debug(test_shopcart)
         test_shopcart.item_id = "test"
+        resp = self.app.post(
+            BASE_URL,
+                json=test_shopcart.serialize(),
+                content_type=CONTENT_TYPE_JSON
+        )
+        self.assertEqual(resp.status_code, status.HTTP_400_BAD_REQUEST)
+    
+    def test_create_shopcart_already_exist(self):
+        """Create a Shopcart that already has items in it"""
+        # create a shopcart with an item
+        test_shopcart = ItemFactory()
+        logging.debug(test_shopcart)
+        resp = self.app.post(
+            BASE_URL,
+                json=test_shopcart.serialize(),
+                content_type=CONTENT_TYPE_JSON
+        )
+        self.assertEqual(resp.status_code, status.HTTP_201_CREATED)
         resp = self.app.post(
             BASE_URL,
                 json=test_shopcart.serialize(),


### PR DESCRIPTION
The success response will contain created items in the shopcart.
If the user tries creating a shopcart that already has items in it, it will show proper error message.
In addition, prices parsed in json now can be int also.