### PR TITLE
refactoring

### DIFF
--- a/features/shopcarts.feature
+++ b/features/shopcarts.feature
@@ -17,8 +17,7 @@ Scenario: Create an empty shopcart which is already non-empty
     When we visit the "home page"
     And we enter "1001" to the text box "User_ID"
     And we press the button "Create-Shopcart"
-    Then we should see status code 400
-    And we should see message "User with id '1001' already has a non-empty shopcart."
+    Then we should see message "User with id '1001' already has a non-empty shopcart"
     When we enter "1001" to the text box "User_ID"
     And we press the button "Retrieve"
     Then we should see "ring1" in the results

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,7 @@
 # Dependencies
 Werkzeug==2.0.3
 Flask==2.0.2
+Flask-RESTX==0.5.1
 Flask-SQLAlchemy==2.5.1
 psycopg2==2.9.2
 python-dotenv==0.19.2

--- a/service/models.py
+++ b/service/models.py
@@ -89,35 +89,35 @@ class Shopcart(db.Model):
             data (dict): A dictionary containing the resource data
         """
         try:
-            if isinstance(data["user_id"], int):
+            if isinstance(data["user_id"], int) and data["user_id"] >= 0:
                 self.user_id = data["user_id"]
             else:
                 raise DataValidationError(
-                    "Invalid type for int [user_id]: "
-                    + str(type(data["user_id"]))
+                    "Invalid type or value for positive int [user_id]: "
+                    + str(type(data["user_id"])) + " with value " + str(data["user_id"])
                 )
-            if isinstance(data["item_id"], int):
+            if isinstance(data["item_id"], int) and data["user_id"] >= 0:
                 self.item_id = data["item_id"]
             else:
                 raise DataValidationError(
                     "Invalid type for int [item_id]: "
-                    + str(type(data["item_id"]))
+                    + str(type(data["item_id"])) + " with value " + str(data["item_id"])
                 )
 
             self.item_name = data["item_name"] + ""
-            if isinstance(data["quantity"], int):
+            if isinstance(data["quantity"], int) and data["quantity"] > 0:
                 self.quantity = data["quantity"]
             else:
                 raise DataValidationError(
                         "Invalid type for int [quantity]: "
-                        + str(type(data["quantity"]))
+                        + str(type(data["quantity"])) + " with value " + str(data["quantity"])
                 )
-            if isinstance(data["price"], float) or isinstance(data["price"], int):
+            if (isinstance(data["price"], float) or isinstance(data["price"], int)) and data["price"] > 0:
                 self.price = data["price"]
             else:
                 raise DataValidationError(
                         "Invalid type for float [price]: "
-                        + str(type(data["price"]))
+                        + str(type(data["price"])) + " with value " + str(data["price"])
                 )
                 
         except KeyError as error:

--- a/service/routes.py
+++ b/service/routes.py
@@ -388,7 +388,7 @@ def create_items(shopcart_id):
         assert isinstance(item["price"], int) or isinstance(item["price"], float)
         assert item["price"] > 0
     except (TypeError, AssertionError, KeyError):
-        app.logger.error("Price must be a non-negative int or float.")
+        app.logger.error("Price must be a positive int or float.")
         abort(status.HTTP_400_BAD_REQUEST, "Price must be a positive int or float.")
 
     if Shopcart.find_item(shopcart_id, item["item_id"]):

--- a/service/routes.py
+++ b/service/routes.py
@@ -386,10 +386,10 @@ def create_items(shopcart_id):
         abort(status.HTTP_400_BAD_REQUEST, "Item_name must be a string.")
     try:
         assert isinstance(item["price"], int) or isinstance(item["price"], float)
-        assert item["price"] >= 0
+        assert item["price"] > 0
     except (TypeError, AssertionError, KeyError):
         app.logger.error("Price must be a non-negative int or float.")
-        abort(status.HTTP_400_BAD_REQUEST, "Price must be a non-negative int or float.")
+        abort(status.HTTP_400_BAD_REQUEST, "Price must be a positive int or float.")
 
     if Shopcart.find_item(shopcart_id, item["item_id"]):
         item_id = item["item_id"]

--- a/service/routes.py
+++ b/service/routes.py
@@ -15,7 +15,8 @@ Usage:
 """
 from werkzeug.exceptions import NotFound
 from flask import jsonify, request, url_for, make_response, abort
-from service.models import Shopcart
+from flask_restx import Api, Resource, fields, reqparse, inputs
+from service.models import Shopcart, DataValidationError, DatabaseConnectionError
 from .utils import status  # HTTP Status Codes
 
 # Import Flask application
@@ -31,101 +32,201 @@ def index():
     return app.send_static_file("index.html")
 
 ######################################################################
-# ADD A NEW SHOPCART
+# Configure Swagger before initializing it
 ######################################################################
-@app.route("/shopcarts", methods=["POST"])
-def create_shopcarts():
-    """
-    Creates a Shopcart
-    This endpoint will create a Shopcart based the data in the body that is posted
-    """
-    app.logger.info("Request to create a shopcart")
-    check_content_type("application/json")
-    req = request.get_json()
-    if not "user_id" in req.keys() or not isinstance(req["user_id"], int):
-        abort(status.HTTP_400_BAD_REQUEST, f"Invalid user id.")
-    if Shopcart.find_shopcart(req["user_id"]):
-        user_id = req["user_id"]
-        abort(
-            status.HTTP_400_BAD_REQUEST, 
-            f"User with id '{user_id}' already has a non-empty shopcart.",
-        )
-    
-    shopcarts = []
-    shopcarts_deserialize = []
-    if "item_id" in req.keys():
-        shopcarts.append(req)
-    elif "items" in req.keys():
-        shopcarts = req["items"]
-    for s in shopcarts:
-        s["user_id"] = req["user_id"]
-        shopcart = Shopcart()
-        shopcart.deserialize(s)
-        shopcart.create()
-        shopcarts_deserialize.append(shopcart)
-    location_url = url_for("get_shopcarts", shopcart_id=req["user_id"], _external=True)
-    app.logger.info("Shopcart with ID [%s] created.", req["user_id"])
-    results = [shopcart.serialize() for shopcart in shopcarts_deserialize]
-    return make_response(
-        jsonify(results), status.HTTP_201_CREATED, {"Location": location_url}
-    )
+api = Api(app,
+          version='1.0.0',
+          title='Shopcart REST API Service',
+          description='This is a Shopcart server.',
+          default='shopcarts',
+          default_label='Shopcart operations',
+          doc='/apidocs', # default also could use doc='/apidocs/'
+          prefix='/'
+         )
+
+# Define the model so that the docs reflect what can be sent
+create_item_model = api.model('Shopcart', {
+    'item_id': fields.Integer(required=True,
+                              description='The ID of the Item'),
+    'item_name': fields.String(required=True,
+                               description='The name of the Item'),
+    'quantity': fields.Integer(required=True,
+                               description='The quantity of the Item'),
+    'price': fields.Float(required=True,
+                          description='The price of the Item')
+})
+
+create_shopcart_model = api.model('Shopcart', {
+    'user_id': fields.Integer(required=True,
+                              description='The ID of the user'),
+    'item_id': fields.Integer(description='The ID of the item'),
+    'item_name': fields.String(description='The name of the item'),
+    'quantity': fields.Integer(description='The quantity of the Item'),
+    'price': fields.Float(description='The price of the Item'),
+    'items': fields.List(fields.Nested(create_item_model),
+                         description='The list of Items (use for multiple items)')
+})
+
+item_model = api.model('Shopcart', {
+    'user_id': fields.Integer(readOnly=True,
+                              description='The ID of the User'),
+    'item_id': fields.Integer(readOnly=True,
+                              description='The ID of the Item'),
+    'item_name': fields.String(readOnly=True,
+                               description='The name of the Item'),
+    'quantity': fields.Integer(description='The quantity of the Item'),
+    'price': fields.Float(description='The price of the Item')
+})
+
+list_shopcart_model = api.model('Shopcart', {
+    'user_id': fields.Integer(readOnly=True,
+                              description='The ID of the User')
+})
 
 ######################################################################
-# LIST ALL SHOPCARTS
+# Special Error Handlers
 ######################################################################
-@app.route("/shopcarts", methods=["GET"])
-def list_shopcarts():
-    """Returns all of the Shopcarts"""
-    app.logger.info("Request for shopcart list")
-    shopcarts = Shopcart.all_shopcart()
-    results = [dict(shopcart) for shopcart in shopcarts]
-    app.logger.info("Returning %d shopcarts", len(results))
-    return make_response(jsonify(results), status.HTTP_200_OK)
+@api.errorhandler(DataValidationError)
+def request_validation_error(error):
+    """ Handles Value Errors from bad data """
+    message = str(error)
+    app.logger.error(message)
+    return {
+        'status_code': status.HTTP_400_BAD_REQUEST,
+        'error': 'Bad Request',
+        'message': message
+    }, status.HTTP_400_BAD_REQUEST
+
+@api.errorhandler(DatabaseConnectionError)
+def database_connection_error(error):
+    """ Handles Database Errors from connection attempts """
+    message = str(error)
+    app.logger.critical(message)
+    return {
+        'status_code': status.HTTP_503_SERVICE_UNAVAILABLE,
+        'error': 'Service Unavailable',
+        'message': message
+    }, status.HTTP_503_SERVICE_UNAVAILABLE
 
 ######################################################################
-# RETRIEVE A SHOPCART
+#  PATH: /shopcarts
 ######################################################################
-@app.route("/shopcarts/<int:shopcart_id>", methods=["GET"])
-def get_shopcarts(shopcart_id):
-    """
-    Retrieve a single Shopcart
-    This endpoint will return a Shopcart based on its id
-    """
-    app.logger.info("Request for shopcart with id: %s", shopcart_id)
-    #This is the list of shopcarts which user_id == shopcart_id
-    shopcart = Shopcart.find_shopcart(shopcart_id) 
-    
-    if not shopcart:
-        return make_response(jsonify([]), status.HTTP_200_OK) 
+@api.route('/shopcarts', strict_slashes=False)
+class ShopcartCollection(Resource):
 
-    app.logger.info("Returning shopcart: %s", shopcart_id)
-    #As 1 user is attached to 1 user_id
-    return make_response(jsonify(
-        [sc.serialize() for sc in shopcart]),
-        status.HTTP_200_OK
-        ) 
+    ######################################################################
+    # ADD A NEW SHOPCART
+    ######################################################################
+    @api.doc('create_shopcarts')
+    @api.response(400, 'Invalid user id')
+    @api.expect(create_shopcart_model)
+    @api.marshal_list_with(item_model, code=201)
+    def post(self):
+        """
+        Creates a Shopcart
+        This endpoint will create a Shopcart based the data in the body that is posted
+        """
+        app.logger.info("Request to create a shopcart")
+        check_content_type("application/json")
+        req = request.get_json()
+        if not "user_id" in req.keys() or not isinstance(req["user_id"], int):
+            abort(status.HTTP_400_BAD_REQUEST, f"Invalid user id.")
+        if Shopcart.find_shopcart(req["user_id"]):
+            user_id = req["user_id"]
+            abort(
+                status.HTTP_400_BAD_REQUEST, 
+                f"User with id '{user_id}' already has a non-empty shopcart.",
+            )
+        
+        shopcarts = []
+        shopcarts_deserialize = []
+        if "item_id" in req.keys():
+            shopcarts.append(req)
+        elif "items" in req.keys():
+            shopcarts = req["items"]
+        for s in shopcarts:
+            s["user_id"] = req["user_id"]
+            shopcart = Shopcart()
+            shopcart.deserialize(s)
+            shopcart.create()
+            shopcarts_deserialize.append(shopcart)
+        location_url = api.url_for(ShopcartResource, user_id=req["user_id"], _external=True)
+        app.logger.info("Shopcart with ID [%s] created.", req["user_id"])
+        results = [shopcart.serialize() for shopcart in shopcarts_deserialize]
+        return results, status.HTTP_201_CREATED, {"Location": location_url}
+
+    ######################################################################
+    # LIST ALL SHOPCARTS
+    ######################################################################
+    @api.doc('list_shopcarts')
+    @api.response(400, 'Invalid user id')
+    @api.marshal_list_with(list_shopcart_model)
+    def get(self):
+        """Returns all of the Shopcarts"""
+        app.logger.info("Request for shopcart list")
+        shopcarts = Shopcart.all_shopcart()
+        results = [dict(shopcart) for shopcart in shopcarts]
+        app.logger.info("Returning %d shopcarts", len(results))
+        return results, status.HTTP_200_OK
+
 
 ######################################################################
-# DELETE A SHOPCART
+#  PATH: /shopcarts/{id}
 ######################################################################
-@app.route("/shopcarts/<int:shopcart_id>", methods=["DELETE"])
-def delete_shopcarts(shopcart_id):
-    """
-    Delete a single Shopcart
-    This endpoint will return a Shopcart based on its id
-    """
-    app.logger.info("Request to delete shopcart with id: %s", shopcart_id)
-    shopcart = Shopcart.find_shopcart(shopcart_id) 
-    if shopcart:
-        for item in shopcart:
-            item.delete()
-    return make_response("", status.HTTP_204_NO_CONTENT)
+@api.route('/shopcarts/<user_id>', strict_slashes=False)
+@api.route('user_id', 'The User identifier')
+class ShopcartResource(Resource):
+
+    ######################################################################
+    # RETRIEVE A SHOPCART
+    ######################################################################
+    @api.doc('get_shopcarts')
+    @api.response(400, 'Invalid user id')
+    @api.marshal_list_with(item_model)
+    def get(self, user_id):
+        """
+        Retrieve a single Shopcart
+        This endpoint will return a Shopcart based on its id
+        """
+        app.logger.info("Request for shopcart with id: %s", user_id)
+        if not user_id.isdigit():
+            abort(status.HTTP_400_BAD_REQUEST, f"Invalid user id")
+        
+        #This is the list of shopcarts which user_id == shopcart_id
+        shopcart = Shopcart.find_shopcart(user_id)         
+        if not shopcart:
+            return [], status.HTTP_200_OK 
+
+        app.logger.info("Returning shopcart: %s", user_id)
+        #As 1 user is attached to 1 user_id
+        return [sc.serialize() for sc in shopcart], status.HTTP_200_OK
+
+
+    ######################################################################
+    # DELETE A SHOPCART
+    ######################################################################
+    @api.doc('delete_shopcarts')
+    @api.response(400, 'Invalid user id')
+    def delete(self, user_id):
+        """
+        Delete a single Shopcart
+        This endpoint will return a Shopcart based on its id
+        """
+        app.logger.info("Request to delete shopcart with id: %s", user_id)
+        if not user_id.isdigit():
+            abort(status.HTTP_400_BAD_REQUEST, f"Invalid user id")
+        
+        shopcart = Shopcart.find_shopcart(user_id) 
+        if shopcart:
+            for item in shopcart:
+                item.delete()
+        return "", status.HTTP_204_NO_CONTENT
 
 ######################################################################
 # UPDATE A SHOPCART (#TODO: TO BE FIXED)
 ######################################################################
-@app.route("/shopcarts/<int:shopcart_id>", methods = ["PUT"])
-def update_shopcarts(shopcart_id):
+# @app.route("/shopcarts/<int:shopcart_id>", methods = ["PUT"])
+# def update_shopcarts(shopcart_id):
     """
     Updates shopcart with the relevant shopcart_id to quantity
 

--- a/service/routes.py
+++ b/service/routes.py
@@ -190,7 +190,7 @@ class ShopcartResource(Resource):
         """
         app.logger.info("Request for shopcart with id: %s", user_id)
         if not user_id.isdigit():
-            abort(status.HTTP_400_BAD_REQUEST, f"Invalid user id")
+            abort(status.HTTP_400_BAD_REQUEST, f"Invalid user id.")
         
         #This is the list of shopcarts which user_id == shopcart_id
         shopcart = Shopcart.find_shopcart(user_id)         
@@ -214,7 +214,7 @@ class ShopcartResource(Resource):
         """
         app.logger.info("Request to delete shopcart with id: %s", user_id)
         if not user_id.isdigit():
-            abort(status.HTTP_400_BAD_REQUEST, f"Invalid user id")
+            abort(status.HTTP_400_BAD_REQUEST, f"Invalid user id.")
         
         shopcart = Shopcart.find_shopcart(user_id) 
         if shopcart:
@@ -519,7 +519,6 @@ def delete_items(shopcart_id, item_id):
 ######################################################################
 #  U T I L I T Y   F U N C T I O N S
 ######################################################################
-
 
 def init_db():
     """ Initializes the SQLAlchemy app """

--- a/tests/factories.py
+++ b/tests/factories.py
@@ -16,5 +16,5 @@ class ItemFactory(factory.Factory):
     user_id = factory.Sequence(lambda n: n)
     item_id = FuzzyInteger(0)
     item_name = "ring" + str(item_id)
-    quantity = FuzzyInteger(0, 999)
+    quantity = FuzzyInteger(1, 999)
     price = FuzzyFloat(0.1)

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -134,7 +134,7 @@ class TestYourResourceServer(TestCase):
     def test_get_shopcart_invalid(self):
         """Get a Shopcart with invalid user id"""
         resp = self.app.get("/shopcarts/s")
-        self.assertEqual(resp.status_code, status.HTTP_404_NOT_FOUND)
+        self.assertEqual(resp.status_code, status.HTTP_400_BAD_REQUEST)
 
 
 

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -103,8 +103,9 @@ class TestYourResourceServer(TestCase):
         self.assertEqual(resp.status_code, status.HTTP_200_OK)
         data = resp.get_json()
         self.assertEqual(len(data), 2)
-        self.assertEqual(data[0]["user_id"], shopcart1[0].user_id)
-        self.assertEqual(data[1]["user_id"], shopcart2[0].user_id)
+        dict1 = {'user_id': shopcart1[0].user_id}
+        dict2 = {'user_id': shopcart2[0].user_id}
+        self.assertCountEqual(data, [dict1,dict2])
 
 
     def test_get_shopcart(self):
@@ -262,6 +263,19 @@ class TestYourResourceServer(TestCase):
         resp = self.app.post(
             BASE_URL,
                 json=test_shopcart.serialize(),
+                content_type=CONTENT_TYPE_JSON
+        )
+        self.assertEqual(resp.status_code, status.HTTP_400_BAD_REQUEST)
+
+    def test_create_shopcart_duplicate_item_id(self):
+        """Create a Shopcart with duplicate item id"""
+        item = ItemFactory()
+        shopcart = [item.serialize(), item.serialize()]       
+        logging.debug(shopcart)
+        resp = self.app.post(
+                BASE_URL,
+                json={"user_id": item.user_id,
+                    "items": shopcart},
                 content_type=CONTENT_TYPE_JSON
         )
         self.assertEqual(resp.status_code, status.HTTP_400_BAD_REQUEST)
@@ -451,6 +465,11 @@ class TestYourResourceServer(TestCase):
         """Delete a Shopcart that's not found"""
         resp = self.app.delete("/shopcarts/0")
         self.assertEqual(resp.status_code, status.HTTP_204_NO_CONTENT)
+
+    def test_delete_shopcart_invalid(self):
+        """Delete a Shopcart with invalid user id"""
+        resp = self.app.delete("/shopcarts/s")
+        self.assertEqual(resp.status_code, status.HTTP_400_BAD_REQUEST)
 
 
     ######################################################################


### PR DESCRIPTION
Professor said that we do not need to have error_handler.py at the end, since restx will handle most errors. I found that it is true but it behaves a little bit different from the error_handler.py, as the string in the 'message' field will not have a prefix showing the error code by default.

Because it is just parts of refactoring, error_handler.py is kept. The test coverage decreases because refactoring code doesn't go to error_handler.py.

In addition, I found the line printed in nosetests is because the log level is critical for that error. @TimothyXu 